### PR TITLE
Refactor createAsistencia function to use alumnoId from req.body

### DIFF
--- a/backend/src/config/configDb.js
+++ b/backend/src/config/configDb.js
@@ -10,6 +10,7 @@ import Anotacion from "../entity/anotacion.entity.js";
 import Apoderado from "../entity/apoderado.entity.js";
 import Curso from "../entity/curso.entity.js";
 import User from "../entity/user.entity.js";
+import Asisencia from "../entity/asistencia.entity.js";
 import { ROLES } from "../entity/roles.js"; // Corregido aquí
 
 export const AppDataSource = new DataSource({
@@ -24,9 +25,11 @@ export const AppDataSource = new DataSource({
     Asignatura,
     Alumno,
     Anotacion,
+    Asisencia,
     Apoderado,
     Curso,
     User,
+
     ROLES, // Usar el nombre exportado correctamente
   ],
   synchronize: true,

--- a/backend/src/controllers/asistencia.controller.js
+++ b/backend/src/controllers/asistencia.controller.js
@@ -22,7 +22,7 @@ export async function createAsistencia(req, res) {
   try {
     const profesor_id = req.user;
 
-    const alumnoId = req.body;
+    const alumnoId = req.body.alumnoId;
 
     const { error } = createAsistenciaValidation.validate(req.body);
 
@@ -35,7 +35,7 @@ export async function createAsistencia(req, res) {
       );
     }
 
-    const asistencia = await createAsistenciaService(id_alumno, profesor_id);
+    const asistencia = await createAsistenciaService(alumnoId);
 
     if (!asistencia) {
       return handleErrorClient(

--- a/backend/src/services/asistencia.service.js
+++ b/backend/src/services/asistencia.service.js
@@ -3,12 +3,13 @@ import { AppDataSource } from "../config/configDb.js";
 import AlumnoSchema from "../entity/alumno.entity.js";
 import AsistenciaSchema from "../entity/asistencia.entity.js";
 
-export async function createAsistenciaService(id_alumno) {
+export async function createAsistenciaService(alumnoId) {
   try {
     const alumnoRepository = AppDataSource.getRepository(AlumnoSchema);
     const asistenciaRepository = AppDataSource.getRepository(AsistenciaSchema);
 
-    const alumno = await alumnoRepository.findOne({ where: { id: id_alumno } });
+    console.log(alumnoId);
+    const alumno = await alumnoRepository.findOne({ where: { id: alumnoId } });
 
     if (!alumno) {
       console.error("Alumno no encontrado");
@@ -41,6 +42,7 @@ export async function createAsistenciaService(id_alumno) {
     return null;
   }
 }
+
 export async function getAsistenciasService() {
   try {
     const asistenciaRepository = AppDataSource.getRepository(AsistenciaSchema);


### PR DESCRIPTION
This pull request refactors the `createAsistencia` function to use the `alumnoId` from the `req.body` instead of directly from the function parameter. This ensures that the correct `alumnoId` is used when creating an `asistencia`.